### PR TITLE
Fixed empty file after immediate upload

### DIFF
--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -216,6 +216,8 @@ class ZEditor extends Component {
     let editorState = EditorState.createWithContent(convertFromRaw(JSON.parse(newEditorState)));
 
     this.setState({ editorState: editorState });
+    //to avoid empty file downloaded after immediate upload without modifications.
+    this.props.setDownloadState(convertToRaw(this.state.editorState.getCurrentContent()));
   };
 
   insertFN = (symbol, type, side) => {


### PR DESCRIPTION
Fixed issue number #61 regarding `downloadState` to be empty after immediate upload without any modifications by setting the `downloadState` to the content inside the `editorState` after uploading the file.