### PR TITLE
feat: Add new font style change options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,6 @@ function App() {
   const editorRef = useRef<Handle>(null);
 
   const handleEditorChange = (newState: EditorState) => {
-    console.log(newState.toJSON());
     setEditorState(newState);
   };
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -21,7 +21,6 @@ const Header: ComponentType<HeaderProps> = ({ editorState, setEditorState }) => 
         const text = await file.text();
         const savedState: unknown = JSON.parse(text);
 
-        console.log(savedState);
         // Reconstruct the EditorState from saved JSON data
         const newState = EditorState.create({
           schema,

--- a/src/components/ToolsBar/commands.ts
+++ b/src/components/ToolsBar/commands.ts
@@ -17,16 +17,17 @@ const toggleSub = toggleMarkCommand(schema.marks.subscript);
 interface FontSizeValue {
   size: string;
 }
+
 interface FontTypeValue {
   type: string;
 }
+
 type MarkKeyValuePair = FontSizeValue | FontTypeValue;
 
 function isFontSizeValue(value: MarkKeyValuePair): value is FontSizeValue {
   return (value as FontSizeValue).size !== undefined;
 }
 
-// Type guard for FontTypeValue
 function isFontTypeValue(value: MarkKeyValuePair): value is FontTypeValue {
   return (value as FontTypeValue).type !== undefined;
 }


### PR DESCRIPTION
Add new font style change options to the ToolsBar component. 
This will enable font change from H1 to H5.
Remove unnecessary console.logs.