### PR TITLE
:sparkles: Enable PNG export for editor content

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "html2canvas": "^1.4.1",
     "prosemirror-commands": "^1.6.0",
     "prosemirror-history": "^1.4.1",
     "prosemirror-keymap": "^1.2.2",

--- a/src/components/DropDownMenu/DropDownMenu.css
+++ b/src/components/DropDownMenu/DropDownMenu.css
@@ -1,0 +1,52 @@
+.dropdown {
+  float: right;
+  position: relative;
+}
+
+.dropdown-button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 20px;
+  color: rgb(255, 255, 255);
+  cursor: pointer;
+  float: right;
+  font-size: 12px;
+  font-weight: bold;
+  margin: 1px 15px;
+  outline: 0;
+  padding: 10px;
+}
+
+.dropdown-button:hover {
+  border: 1px solid rgba(255, 255, 255, 0.51);
+  color: rgb(255, 255, 255);
+}
+
+.dropdown-menu {
+  background-color: #f9f9f9;
+  border-radius: 20px;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+  left: 0;
+  list-style: none;
+  margin: 0;
+  min-width: 100px;
+  padding: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 1;
+}
+
+.dropdown-menu li {
+  color: black;
+  cursor: pointer;
+  display: block;
+  font-size: 12px;
+  padding: 12px 28px;
+  text-decoration: none;
+}
+
+.dropdown-menu li:hover {
+  background-color: #f1f1f1;
+  border-radius: 20px;
+  border: 1px solid black;
+}

--- a/src/components/DropDownMenu/DropDownMenu.spec.tsx
+++ b/src/components/DropDownMenu/DropDownMenu.spec.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DropDownMenu } from './DropDownMenu';
+
+describe('DropDownMenu', () => {
+  it('renders the button with the provided text', () => {
+    render(<DropDownMenu text="Options" options={[]} />);
+
+    expect(screen.getByText('Options')).toBeInTheDocument();
+  });
+
+  it('opens the dropdown menu when the button is clicked and closes when clicked again', () => {
+    render(<DropDownMenu text="Options" options={[{ label: 'Option 1', onClick: vi.fn() }]} />);
+    const button = screen.getByText('Options');
+
+    fireEvent.click(button);
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+  });
+
+  it('calls the onClick handler and closes the dropdown when an option is clicked', () => {
+    const onClick = vi.fn();
+    const options = [{ label: 'Option 1', onClick }];
+    render(<DropDownMenu text="Options" options={options} />);
+
+    const button = screen.getByText('Options');
+
+    fireEvent.click(button);
+
+    const option = screen.getByText('Option 1');
+
+    fireEvent.click(option);
+
+    expect(onClick).toHaveBeenCalled();
+
+    expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/src/components/DropDownMenu/DropDownMenu.tsx
@@ -1,0 +1,38 @@
+import './DropdownMenu.css';
+
+import React, { useState } from 'react';
+
+interface DropdownMenuProps {
+  text: string;
+  options: {
+    label: string;
+    onClick: () => void;
+  }[];
+}
+
+export const DropDownMenu: React.FC<DropdownMenuProps> = ({ text, options }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="dropdown">
+      <button className="dropdown-button" onClick={() => setIsOpen(!isOpen)}>
+        {text}
+      </button>
+      {isOpen && (
+        <ul className="dropdown-menu">
+          {options.map((option, index) => (
+            <li
+              key={index}
+              onClick={() => {
+                option.onClick();
+                setIsOpen(false);
+              }}
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/components/DropDownMenu/index.ts
+++ b/src/components/DropDownMenu/index.ts
@@ -1,0 +1,1 @@
+export { DropDownMenu } from './DropDownMenu';

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -64,7 +64,7 @@ export default forwardRef<Handle, Props>(function ProseMirror(props, ref): JSX.E
       return viewRef.current;
     },
   }));
-  return <div ref={root} style={props.style} className={props.className} />;
+  return <div id="content-container" ref={root} style={props.style} className={props.className} />;
 
   function buildProps(props: Partial<Props>): Partial<DirectEditorProps> {
     return {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,9 +2,11 @@ import './Header.css';
 
 import { EditorState } from 'prosemirror-state';
 import { ComponentType, useCallback, useRef } from 'react';
+import html2canvas from 'html2canvas';
 
 import { schema } from '../Editor';
 import { HeaderButton } from '../HeaderButton';
+import { DropDownMenu } from '../DropDownMenu';
 
 interface HeaderProps {
   editorState: EditorState;
@@ -62,6 +64,34 @@ const Header: ComponentType<HeaderProps> = ({ editorState, setEditorState }) => 
     URL.revokeObjectURL(url);
   };
 
+  const exportAsPNG = async () => {
+    const contentContainer = document.getElementById('content-container');
+    if (!contentContainer) {
+      return;
+    }
+
+    const canvas = await html2canvas(contentContainer, {
+      backgroundColor: '#ffffff',
+      scale: 2,
+      useCORS: true,
+    });
+
+    const dataUrl = canvas.toDataURL('image/png');
+
+    const link = document.createElement('a');
+
+    const fileName = window.prompt('Enter the name for the PNG file', 'zeditor_export.png');
+    if (!fileName) {
+      return;
+    }
+
+    link.download = fileName.endsWith('.png') ? fileName : `${fileName}.png`;
+    link.href = dataUrl;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   return (
     <div className="header">
       <div className="logo">Z-Editor</div>
@@ -90,6 +120,19 @@ const Header: ComponentType<HeaderProps> = ({ editorState, setEditorState }) => 
             await handleFileChange(e);
           })();
         }}
+      />
+      <DropDownMenu
+        text="Export"
+        options={[
+          {
+            label: '- PNG',
+            onClick: () => {
+              void (async () => {
+                await exportAsPNG();
+              })();
+            },
+          },
+        ]}
       />
       <HeaderButton text="Import" onClick={triggerUpload} />
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,6 +1637,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64-arraybuffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 10c0/3acac95c70f9406e87a41073558ba85b6be9dbffb013a3d2a710e3f2d534d506c911847d5d9be4de458af6362c676de0a5c4c2d7bdf4def502d00b313368e72f
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -1846,6 +1853,15 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
+  languageName: node
+  linkType: hard
+
+"css-line-break@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "css-line-break@npm:2.1.0"
+  dependencies:
+    utrie: "npm:^1.0.2"
+  checksum: 10c0/b2222d99d5daf7861ecddc050244fdce296fad74b000dcff6bdfb1eb16dc2ef0b9ffe2c1c965e3239bd05ebe9eadb6d5438a91592fa8648d27a338e827cf9048
   languageName: node
   linkType: hard
 
@@ -3010,6 +3026,16 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
+  languageName: node
+  linkType: hard
+
+"html2canvas@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "html2canvas@npm:1.4.1"
+  dependencies:
+    css-line-break: "npm:^2.1.0"
+    text-segmentation: "npm:^1.0.3"
+  checksum: 10c0/6de86f75762b00948edf2ea559f16da0a1ec3facc4a8a7d3f35fcec59bb0c5970463478988ae3d9082152e0173690d46ebf4082e7ac803dd4817bae1d355c0db
   languageName: node
   linkType: hard
 
@@ -4969,6 +4995,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-segmentation@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "text-segmentation@npm:1.0.3"
+  dependencies:
+    utrie: "npm:^1.0.2"
+  checksum: 10c0/8b9ae8524e3a332371060d0ca62f10ad49a13e954719ea689a6c3a8b8c15c8a56365ede2bb91c322fb0d44b6533785f0da603e066b7554d052999967fb72d600
+  languageName: node
+  linkType: hard
+
 "tinybench@npm:^2.9.0":
   version: 2.9.0
   resolution: "tinybench@npm:2.9.0"
@@ -5211,6 +5246,15 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"utrie@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "utrie@npm:1.0.2"
+  dependencies:
+    base64-arraybuffer: "npm:^1.0.2"
+  checksum: 10c0/eaffe645bd81a39e4bc3abb23df5895e9961dbdd49748ef3b173529e8b06ce9dd1163e9705d5309a1c61ee41ffcb825e2043bc0fd1659845ffbdf4b1515dfdb4
   languageName: node
   linkType: hard
 
@@ -5647,6 +5691,7 @@ __metadata:
     eslint-plugin-react-refresh: "npm:^0.4.9"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     globals: "npm:^15.9.0"
+    html2canvas: "npm:^1.4.1"
     jsdom: "npm:^26.0.0"
     prettier: "npm:^3.3.3"
     prosemirror-commands: "npm:^1.6.0"


### PR DESCRIPTION
Previously, the editor content could not be exported as a PNG. This commit integrates the https://html2canvas.hertzen.com/ library to capture the editor’s DOM content as an image and enable PNG downloads.

Key changes in this PR:

1. Added `DropDownMenu` component.
2. Added `Export` button with `PNG` option in Header.

This is the work requested in #59