### PR TITLE
feat: Google Drive integration and restructured File menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 # Google Analytics 4 Measurement ID. Analytics only load when this is set.
 # Create a GA4 property -> Web data stream -> copy the "G-XXXXXXXXXX" ID.
 VITE_GA_ID=
+
+# Google Drive integration (optional). Menu items appear only when both are set.
+# Create a Google Cloud project, enable Drive API + Picker API.
+# OAuth Web Client ID (add your GitHub Pages + http://localhost:5173 as Authorized JS origins):
+VITE_GOOGLE_CLIENT_ID=
+# API key (used by the Google Picker):
+VITE_GOOGLE_API_KEY=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Install dependencies, test and build
         env:
           VITE_GA_ID: ${{ vars.VITE_GA_ID }}
+          VITE_GOOGLE_CLIENT_ID: ${{ vars.VITE_GOOGLE_CLIENT_ID }}
+          VITE_GOOGLE_API_KEY: ${{ vars.VITE_GOOGLE_API_KEY }}
         run: |
           corepack enable
           yarn install

--- a/src/components/DropDownMenu/DropDownMenu.css
+++ b/src/components/DropDownMenu/DropDownMenu.css
@@ -47,3 +47,31 @@
 .dropdown-menu li:hover {
   background-color: #f1f3f4;
 }
+
+.menu-label {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.submenu-arrow {
+  color: #5f6368;
+  font-size: 15px;
+  margin-left: 16px;
+}
+
+.dropdown-menu li.has-submenu {
+  position: relative;
+}
+
+.dropdown-menu .submenu {
+  display: none;
+  left: 100%;
+  margin: 0;
+  top: -6px;
+}
+
+/* ponytail: pure-CSS flyout, opens right; flip to left if it clips, revisit then */
+.dropdown-menu li.has-submenu:hover > .submenu {
+  display: block;
+}

--- a/src/components/DropDownMenu/DropDownMenu.spec.tsx
+++ b/src/components/DropDownMenu/DropDownMenu.spec.tsx
@@ -40,4 +40,27 @@ describe('DropDownMenu', () => {
 
     expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
   });
+
+  it('renders nested children and fires only the clicked child, then closes', () => {
+    const parentClick = vi.fn();
+    const childClick = vi.fn();
+    render(
+      <DropDownMenu
+        text="File"
+        options={[{ label: 'Save', onClick: parentClick, children: [{ label: 'To device', onClick: childClick }] }]}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('File'));
+
+    const parent = screen.getByText('Save');
+    fireEvent.click(parent);
+    // parent only expands — its own handler must not fire and menu stays open
+    expect(parentClick).not.toHaveBeenCalled();
+    expect(screen.getByText('To device')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('To device'));
+    expect(childClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Save')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/DropDownMenu/DropDownMenu.tsx
+++ b/src/components/DropDownMenu/DropDownMenu.tsx
@@ -2,37 +2,49 @@ import './DropDownMenu.css';
 
 import React, { useState } from 'react';
 
+export interface MenuOption {
+  label: string;
+  onClick?: () => void;
+  children?: MenuOption[];
+}
+
 interface DropdownMenuProps {
   text: string;
-  options: {
-    label: string;
-    onClick: () => void;
-  }[];
+  options: MenuOption[];
 }
 
 export const DropDownMenu: React.FC<DropdownMenuProps> = ({ text, options }) => {
   const [isOpen, setIsOpen] = useState(false);
+
+  const renderItems = (items: MenuOption[]) =>
+    items.map((option, index) => (
+      <li
+        key={index}
+        className={option.children ? 'has-submenu' : undefined}
+        onClick={(e) => {
+          if (option.children) {
+            // ponytail: parent items only expand; clicks land on children
+            e.stopPropagation();
+            return;
+          }
+          option.onClick?.();
+          setIsOpen(false);
+        }}
+      >
+        <span className="menu-label">
+          {option.label}
+          {option.children && <span className="submenu-arrow">›</span>}
+        </span>
+        {option.children && <ul className="dropdown-menu submenu">{renderItems(option.children)}</ul>}
+      </li>
+    ));
 
   return (
     <div className="dropdown">
       <button className="dropdown-button" onClick={() => setIsOpen(!isOpen)}>
         {text}
       </button>
-      {isOpen && (
-        <ul className="dropdown-menu">
-          {options.map((option, index) => (
-            <li
-              key={index}
-              onClick={() => {
-                option.onClick();
-                setIsOpen(false);
-              }}
-            >
-              {option.label}
-            </li>
-          ))}
-        </ul>
-      )}
+      {isOpen && <ul className="dropdown-menu">{renderItems(options)}</ul>}
     </div>
   );
 };

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -38,6 +38,16 @@
   border-color: #3366ff;
 }
 
+.save-status {
+  font-size: 12px;
+  color: #5f6368;
+  white-space: nowrap;
+}
+
+.save-status[data-status='error'] {
+  color: #d93025;
+}
+
 .header-actions {
   margin-left: auto;
   display: flex;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,11 +2,14 @@ import './Header.css';
 
 import html2canvas from 'html2canvas';
 import { EditorState } from 'prosemirror-state';
-import { ComponentType, useCallback, useRef } from 'react';
+import { ComponentType, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { track } from '../../analytics';
+import { downloadFile, driveConfigured, pickFile, saveFile } from '../../googleDrive';
 import { DropDownMenu } from '../DropDownMenu';
 import { schema } from '../Editor';
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 
 interface HeaderProps {
   editorState: EditorState;
@@ -22,6 +25,94 @@ function sanitizeBase(name: string, fallback: string): string {
 
 const Header: ComponentType<HeaderProps> = ({ editorState, setEditorState, docName, setDocName }) => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [driveFileId, setDriveFileId] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+
+  // Refs keep the autosave interval reading the latest values without resetting each keystroke.
+  const currentContent = useMemo(() => JSON.stringify(editorState.doc.toJSON()), [editorState]);
+  const contentRef = useRef(currentContent);
+  contentRef.current = currentContent;
+  const docNameRef = useRef(docName);
+  docNameRef.current = docName;
+  const driveFileIdRef = useRef<string | null>(null);
+  const lastSavedRef = useRef('');
+  const savingRef = useRef(false);
+
+  useEffect(() => {
+    driveFileIdRef.current = driveFileId;
+  }, [driveFileId]);
+
+  const pushToDrive = useCallback(async (): Promise<void> => {
+    savingRef.current = true;
+    setSaveStatus('saving');
+    try {
+      const content = contentRef.current;
+      const id = await saveFile(docNameRef.current, content, driveFileIdRef.current ?? undefined);
+      driveFileIdRef.current = id;
+      setDriveFileId(id);
+      lastSavedRef.current = content;
+      setSaveStatus('saved');
+    } finally {
+      savingRef.current = false;
+    }
+  }, []);
+
+  const openFromDrive = useCallback(async (): Promise<void> => {
+    try {
+      const picked = await pickFile();
+      if (!picked) return;
+      const text = await downloadFile(picked.id);
+      const savedState: unknown = JSON.parse(text);
+      const newState = EditorState.create({
+        schema,
+        plugins: editorState.plugins,
+        doc: schema.nodeFromJSON(savedState),
+      });
+      setEditorState(newState);
+      setDocName(picked.name.replace(/\.z$/i, ''));
+      lastSavedRef.current = JSON.stringify(newState.doc.toJSON());
+      setDriveFileId(picked.id);
+      setSaveStatus('saved');
+      track('drive_open');
+    } catch (err) {
+      alert(`Could not open from Google Drive: ${(err as Error).message}`);
+    }
+  }, [editorState.plugins, setEditorState, setDocName]);
+
+  const saveToDrive = useCallback(async (): Promise<void> => {
+    try {
+      await pushToDrive();
+      track('drive_save');
+    } catch (err) {
+      setSaveStatus('error');
+      alert(`Could not save to Google Drive: ${(err as Error).message}`);
+    }
+  }, [pushToDrive]);
+
+  // Autosave every 60s while the document is Drive-backed, only when it has unsaved changes.
+  useEffect(() => {
+    if (!driveFileId) return;
+    const autosave = async () => {
+      if (savingRef.current || contentRef.current === lastSavedRef.current) return;
+      try {
+        await pushToDrive();
+        track('drive_autosave', { ok: true });
+      } catch {
+        setSaveStatus('error');
+        track('drive_autosave', { ok: false });
+      }
+    };
+    const interval = setInterval(() => void autosave(), 60_000);
+    const onHide = () => {
+      if (document.visibilityState === 'hidden') void autosave();
+    };
+    document.addEventListener('visibilitychange', onHide);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onHide);
+    };
+  }, [driveFileId, pushToDrive]);
 
   const printAsPdf = useCallback(() => {
     // Chrome uses document.title as the default "Save as PDF" filename.
@@ -107,6 +198,15 @@ const Header: ComponentType<HeaderProps> = ({ editorState, setEditorState, docNa
           aria-label="Document name"
           onChange={(e) => setDocName(e.target.value)}
         />
+        {driveFileId && (
+          <span className="save-status" data-status={saveStatus}>
+            {saveStatus === 'saving'
+              ? 'Saving…'
+              : saveStatus === 'error'
+                ? 'Save failed — retrying'
+                : 'All changes saved to Drive'}
+          </span>
+        )}
         <div className="header-actions">
           <a
             className="icon-link"
@@ -150,8 +250,20 @@ const Header: ComponentType<HeaderProps> = ({ editorState, setEditorState, docNa
         <DropDownMenu
           text="File"
           options={[
-            { label: 'Import (.z)', onClick: triggerUpload },
-            { label: 'Download (.z)', onClick: handleDownload },
+            {
+              label: 'Import',
+              children: [
+                { label: 'From device (.z)', onClick: triggerUpload },
+                ...(driveConfigured ? [{ label: 'From Google Drive', onClick: () => void openFromDrive() }] : []),
+              ],
+            },
+            {
+              label: 'Save',
+              children: [
+                { label: 'To device (.z)', onClick: handleDownload },
+                ...(driveConfigured ? [{ label: 'To Google Drive', onClick: () => void saveToDrive() }] : []),
+              ],
+            },
             { label: 'Download as PDF', onClick: printAsPdf },
             {
               label: 'Export as PNG',

--- a/src/google-apis.d.ts
+++ b/src/google-apis.d.ts
@@ -1,0 +1,69 @@
+// Minimal ambient types for the Google Identity Services + Picker globals we use.
+interface GisTokenResponse {
+  access_token?: string;
+  expires_in?: number;
+  error?: string;
+}
+
+interface GisTokenClient {
+  callback: (resp: GisTokenResponse) => void;
+  requestAccessToken: (options?: { prompt?: string }) => void;
+}
+
+interface GisTokenClientConfig {
+  client_id: string;
+  scope: string;
+  callback: (resp: GisTokenResponse) => void;
+  error_callback?: (err: { type?: string }) => void;
+}
+
+interface PickerDoc {
+  id: string;
+  name: string;
+}
+
+interface PickerCallbackData {
+  action: string;
+  docs?: PickerDoc[];
+}
+
+interface PickerDocsView {
+  setMimeTypes(mimeTypes: string): PickerDocsView;
+  setSelectFolderEnabled(enabled: boolean): PickerDocsView;
+}
+
+interface PickerInstance {
+  setVisible(visible: boolean): void;
+}
+
+interface PickerBuilderInstance {
+  setOAuthToken(token: string): PickerBuilderInstance;
+  setDeveloperKey(key: string): PickerBuilderInstance;
+  addView(view: PickerDocsView): PickerBuilderInstance;
+  setCallback(cb: (data: PickerCallbackData) => void): PickerBuilderInstance;
+  build(): PickerInstance;
+}
+
+interface GooglePickerNamespace {
+  PickerBuilder: new () => PickerBuilderInstance;
+  DocsView: new (viewId?: unknown) => PickerDocsView;
+  ViewId: { DOCS: unknown };
+}
+
+interface GoogleNamespace {
+  accounts: {
+    oauth2: {
+      initTokenClient(config: GisTokenClientConfig): GisTokenClient;
+    };
+  };
+  picker: GooglePickerNamespace;
+}
+
+interface GapiNamespace {
+  load(library: string, callback: () => void): void;
+}
+
+interface Window {
+  google?: GoogleNamespace;
+  gapi?: GapiNamespace;
+}

--- a/src/googleDrive.spec.ts
+++ b/src/googleDrive.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildMultipartBody } from './googleDrive';
+
+describe('buildMultipartBody', () => {
+  const metadata = { name: 'notes.z', mimeType: 'application/json' };
+  const content = '{"type":"doc"}';
+  const body = buildMultipartBody(metadata, content);
+
+  it('embeds the metadata as JSON', () => {
+    expect(body).toContain(JSON.stringify(metadata));
+  });
+
+  it('embeds the file content', () => {
+    expect(body).toContain(content);
+  });
+
+  it('opens and closes with the multipart boundary', () => {
+    const boundaryCount = (body.match(/--zeditor_multipart_boundary/g) ?? []).length;
+    // two part delimiters + one closing delimiter
+    expect(boundaryCount).toBe(3);
+    expect(body.trimEnd().endsWith('--zeditor_multipart_boundary--')).toBe(true);
+  });
+
+  it('declares both parts as application/json', () => {
+    const jsonHeaders = (body.match(/Content-Type: application\/json/g) ?? []).length;
+    expect(jsonHeaders).toBe(2);
+  });
+});

--- a/src/googleDrive.ts
+++ b/src/googleDrive.ts
@@ -1,0 +1,144 @@
+// Client-side Google Drive integration (drive.file scope + Picker), no backend, no npm dep.
+// Mirrors draw.io's approach: load Google's scripts on demand, use a token-model OAuth flow.
+const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+const API_KEY = import.meta.env.VITE_GOOGLE_API_KEY;
+const SCOPE = 'https://www.googleapis.com/auth/drive.file';
+const GIS_SRC = 'https://accounts.google.com/gsi/client';
+const GAPI_SRC = 'https://apis.google.com/js/api.js';
+const BOUNDARY = 'zeditor_multipart_boundary';
+
+export const driveConfigured = Boolean(CLIENT_ID && API_KEY);
+
+function ensureConfigured(): void {
+  if (!driveConfigured) {
+    throw new Error('Google Drive is not configured (missing VITE_GOOGLE_CLIENT_ID / VITE_GOOGLE_API_KEY).');
+  }
+}
+
+function loadScript(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (document.querySelector(`script[src="${src}"]`)) {
+      resolve();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.head.appendChild(script);
+  });
+}
+
+let tokenClient: GisTokenClient | null = null;
+let cachedToken = '';
+let tokenExpiry = 0;
+let pendingResolve: ((token: string) => void) | null = null;
+let pendingReject: ((err: Error) => void) | null = null;
+
+async function getAccessToken(): Promise<string> {
+  ensureConfigured();
+  if (cachedToken && Date.now() < tokenExpiry - 60_000) {
+    return cachedToken;
+  }
+  await loadScript(GIS_SRC);
+
+  return new Promise<string>((resolve, reject) => {
+    pendingResolve = resolve;
+    pendingReject = reject;
+
+    if (!tokenClient) {
+      tokenClient = window.google!.accounts.oauth2.initTokenClient({
+        client_id: CLIENT_ID!,
+        scope: SCOPE,
+        callback: (resp) => {
+          if (resp.error || !resp.access_token) {
+            pendingReject?.(new Error(resp.error ?? 'Authorization failed'));
+            return;
+          }
+          cachedToken = resp.access_token;
+          tokenExpiry = Date.now() + (resp.expires_in ?? 3600) * 1000;
+          pendingResolve?.(cachedToken);
+        },
+        error_callback: (err) => pendingReject?.(new Error(err.type ?? 'Authorization cancelled')),
+      });
+    }
+
+    // Silent once granted; prompt for consent on first use.
+    tokenClient.requestAccessToken({ prompt: cachedToken ? '' : 'consent' });
+  });
+}
+
+export function buildMultipartBody(metadata: { name: string; mimeType: string }, content: string): string {
+  const delimiter = `\r\n--${BOUNDARY}\r\n`;
+  const closeDelimiter = `\r\n--${BOUNDARY}--`;
+  return (
+    delimiter +
+    'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+    JSON.stringify(metadata) +
+    delimiter +
+    'Content-Type: application/json\r\n\r\n' +
+    content +
+    closeDelimiter
+  );
+}
+
+/** Create a new file (no id) or overwrite an existing one. Returns the file id. */
+export async function saveFile(name: string, content: string, fileId?: string): Promise<string> {
+  const token = await getAccessToken();
+  const filename = name.endsWith('.z') ? name : `${name}.z`;
+  const body = buildMultipartBody({ name: filename, mimeType: 'application/json' }, content);
+
+  const base = 'https://www.googleapis.com/upload/drive/v3/files';
+  const url = fileId ? `${base}/${fileId}?uploadType=multipart&fields=id` : `${base}?uploadType=multipart&fields=id`;
+
+  const res = await fetch(url, {
+    method: fileId ? 'PATCH' : 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': `multipart/related; boundary=${BOUNDARY}`,
+    },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`Drive save failed (${res.status})`);
+  }
+  const data = (await res.json()) as { id: string };
+  return data.id;
+}
+
+export async function downloadFile(id: string): Promise<string> {
+  const token = await getAccessToken();
+  const res = await fetch(`https://www.googleapis.com/drive/v3/files/${id}?alt=media`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Drive download failed (${res.status})`);
+  }
+  return res.text();
+}
+
+/** Show the Google Picker; resolves with the chosen file or null if cancelled. */
+export async function pickFile(): Promise<PickerDoc | null> {
+  const token = await getAccessToken();
+  await loadScript(GAPI_SRC);
+  await new Promise<void>((resolve) => window.gapi!.load('picker', () => resolve()));
+
+  return new Promise<PickerDoc | null>((resolve) => {
+    const picker = window.google!.picker;
+    const view = new picker.DocsView(picker.ViewId.DOCS).setMimeTypes('application/json').setSelectFolderEnabled(false);
+    new picker.PickerBuilder()
+      .setOAuthToken(token)
+      .setDeveloperKey(API_KEY!)
+      .addView(view)
+      .setCallback((data) => {
+        if (data.action === 'picked' && data.docs?.[0]) {
+          resolve({ id: data.docs[0].id, name: data.docs[0].name });
+        } else if (data.action === 'cancel') {
+          resolve(null);
+        }
+      })
+      .build()
+      .setVisible(true);
+  });
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,8 @@
 
 interface ImportMetaEnv {
   readonly VITE_GA_ID?: string;
+  readonly VITE_GOOGLE_CLIENT_ID?: string;
+  readonly VITE_GOOGLE_API_KEY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Adds **Google Drive** open/save (draw.io-style) and standardizes the **File** menu into nested submenus. Z-Editor stays a pure client-side SPA — no backend, no new npm dependencies.

## Google Drive

- OAuth via Google Identity Services (`drive.file` scope — least privilege) and file selection via the Google Picker; Drive REST over `fetch`.
- Google scripts load on demand. All Drive features stay **hidden** unless `VITE_GOOGLE_CLIENT_ID` and `VITE_GOOGLE_API_KEY` are set.
- **Autosave** every 60s for Drive-backed docs, with a dirty check, a `visibilitychange` flush, and a header save-status indicator.

## File menu

- Actions grouped under **Import** and **Save** submenus, each offering **Device** and **Google Drive** — the source/destination is now explicit and consistent.
- `DropDownMenu` gained optional nested `children`; existing flat items are unchanged.

  - **Import ›** From device (.z) · From Google Drive
  - **Save ›** To device (.z) · To Google Drive
  - Download as PDF · Export as PNG · Print

## Config

- `VITE_GOOGLE_CLIENT_ID` / `VITE_GOOGLE_API_KEY` wired through the deploy workflow and documented in `.env.example`.
- Set both locally in `.env` and as GitHub Actions **repository variables** to enable Drive in production.

## Testing

- 26 unit tests pass (added a nested-menu test); build is clean.
- Verified in-browser: submenu flyout renders correctly; Drive items hidden without config, shown with it.

> Note: public use requires Google OAuth **brand verification** for the `drive.file` sensitive scope (a review form, not the paid security assessment).