### PR TITLE
feat: Privacy Policy and Terms of Service pages

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Privacy Policy · Z-Editor</title>
+    <meta name="robots" content="index, follow" />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        margin: 0;
+        background: #f8f9fa;
+        color: #202124;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        line-height: 1.6;
+      }
+      .wrap {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: 32px 20px 64px;
+      }
+      header.brand {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        margin-bottom: 8px;
+      }
+      header.brand a {
+        color: #1a73e8;
+        font-size: 22px;
+        font-weight: 700;
+        text-decoration: none;
+      }
+      header.brand span {
+        color: #5f6368;
+        font-size: 14px;
+      }
+      h1 {
+        font-size: 28px;
+        margin: 16px 0 4px;
+      }
+      h2 {
+        font-size: 18px;
+        margin: 28px 0 8px;
+      }
+      .updated {
+        color: #5f6368;
+        font-size: 14px;
+      }
+      a {
+        color: #1a73e8;
+      }
+      code {
+        background: #eef0f2;
+        border-radius: 4px;
+        padding: 1px 5px;
+        font-size: 90%;
+      }
+      .callout {
+        background: #e8f0fe;
+        border: 1px solid #d2e3fc;
+        border-radius: 8px;
+        padding: 12px 16px;
+        margin: 20px 0;
+      }
+      footer {
+        margin-top: 40px;
+        border-top: 1px solid #e0e0e0;
+        padding-top: 16px;
+        color: #5f6368;
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <header class="brand">
+        <a href="/">Z-Editor</a>
+        <span>Privacy Policy</span>
+      </header>
+
+      <h1>Privacy Policy</h1>
+      <p class="updated">Last updated: 12 July 2026</p>
+
+      <p>
+        Z-Editor ("the app", "we", "us") is a free, open-source document editor that runs entirely
+        in your web browser. This policy explains what information the app handles and how. By using
+        Z-Editor you agree to this policy.
+      </p>
+
+      <h2>1. Who we are and how the app works</h2>
+      <p>
+        Z-Editor is a client-side single-page application hosted on GitHub Pages. There is no
+        Z-Editor account and no Z-Editor server or database. Your documents are processed locally in
+        your browser and are stored only where you choose to keep them — on your own device or in
+        your own Google Drive. We never receive, transmit, or store the contents of your documents on
+        our own infrastructure.
+      </p>
+
+      <h2>2. Information we handle</h2>
+      <p><strong>a) Usage analytics (Google Analytics 4).</strong> If enabled, the app uses Google
+        Analytics to collect anonymous, aggregated usage data — such as page views, feature
+        interactions, approximate geographic region, browser type, device type, and screen size. This
+        helps us understand how the app is used and where to improve it. It is not used to identify
+        you personally. See
+        <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer"
+          >Google's Privacy Policy</a
+        >
+        and
+        <a
+          href="https://support.google.com/analytics/answer/6004245"
+          target="_blank"
+          rel="noopener noreferrer"
+          >how Google Analytics safeguards data</a
+        >.
+      </p>
+      <p><strong>b) Google Drive (optional).</strong> If you choose to open or save documents with
+        Google Drive, the app requests the
+        <code>drive.file</code> permission. This is a per-file scope: the app can only access the
+        specific files that you open or create with Z-Editor through the Google file picker. It cannot
+        see or access any other files in your Drive. The OAuth access token is held only in your
+        browser's memory for the current session and is not stored on any server. Document content
+        exchanged with Google Drive goes directly between your browser and Google's APIs — it never
+        passes through our servers.
+      </p>
+
+      <div class="callout">
+        <strong>Google API Services User Data Policy — Limited Use.</strong>
+        Z-Editor's use and transfer of information received from Google APIs adheres to the
+        <a
+          href="https://developers.google.com/terms/api-services-user-data-policy"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Google API Services User Data Policy</a
+        >, including the Limited Use requirements. We only use Google Drive data to provide the app's
+        open/save features at your direction; we do not transfer or sell it, do not use it for
+        advertising, and do not allow humans to read it except as required for security, to comply
+        with the law, or with your explicit consent.
+      </div>
+
+      <h2>3. Local storage and cookies</h2>
+      <p>
+        The app may use your browser's local storage to remember settings and, where applicable,
+        Google Analytics may set cookies for measurement. No sensitive personal data is stored this
+        way. You can clear this at any time through your browser settings.
+      </p>
+
+      <h2>4. Data sharing and selling</h2>
+      <p>
+        We do not sell your data and we do not share it with third parties beyond the service
+        providers named here (Google, for Analytics and Drive; GitHub, for hosting). Each processes
+        data under its own privacy policy.
+      </p>
+
+      <h2>5. Data retention</h2>
+      <p>
+        Because we operate no server, we retain no personal data. Documents remain in your device or
+        Google Drive under your control. Analytics data is retained by Google according to the
+        property's configured retention period.
+      </p>
+
+      <h2>6. Children</h2>
+      <p>
+        Z-Editor is not directed to children under 13, and we do not knowingly collect personal
+        information from them.
+      </p>
+
+      <h2>7. Changes to this policy</h2>
+      <p>
+        We may update this policy from time to time. Changes are posted on this page with a new "Last
+        updated" date.
+      </p>
+
+      <h2>8. Contact</h2>
+      <p>
+        Questions about this policy or your data? Email
+        <a href="mailto:opensldev@gmail.com">opensldev@gmail.com</a> or open an issue on
+        <a
+          href="https://github.com/Z-Editor/Z-Editor/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          >GitHub</a
+        >.
+      </p>
+
+      <footer>
+        <a href="/">&larr; Back to Z-Editor</a> · <a href="/terms.html">Terms of Service</a>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Terms of Service · Z-Editor</title>
+    <meta name="robots" content="index, follow" />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        margin: 0;
+        background: #f8f9fa;
+        color: #202124;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        line-height: 1.6;
+      }
+      .wrap {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: 32px 20px 64px;
+      }
+      header.brand {
+        display: flex;
+        align-items: baseline;
+        gap: 12px;
+        margin-bottom: 8px;
+      }
+      header.brand a {
+        color: #1a73e8;
+        font-size: 22px;
+        font-weight: 700;
+        text-decoration: none;
+      }
+      header.brand span {
+        color: #5f6368;
+        font-size: 14px;
+      }
+      h1 {
+        font-size: 28px;
+        margin: 16px 0 4px;
+      }
+      h2 {
+        font-size: 18px;
+        margin: 28px 0 8px;
+      }
+      .updated {
+        color: #5f6368;
+        font-size: 14px;
+      }
+      a {
+        color: #1a73e8;
+      }
+      code {
+        background: #eef0f2;
+        border-radius: 4px;
+        padding: 1px 5px;
+        font-size: 90%;
+      }
+      footer {
+        margin-top: 40px;
+        border-top: 1px solid #e0e0e0;
+        padding-top: 16px;
+        color: #5f6368;
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <header class="brand">
+        <a href="/">Z-Editor</a>
+        <span>Terms of Service</span>
+      </header>
+
+      <h1>Terms of Service</h1>
+      <p class="updated">Last updated: 12 July 2026</p>
+
+      <h2>1. Acceptance of terms</h2>
+      <p>
+        By accessing or using Z-Editor ("the app"), you agree to these Terms of Service. If you do
+        not agree, please do not use the app.
+      </p>
+
+      <h2>2. The service</h2>
+      <p>
+        Z-Editor is a free, open-source document editor that runs entirely in your web browser. It is
+        provided at no charge and without any account. There is no Z-Editor server that stores your
+        documents; your work stays on your device or in storage you connect, such as your own Google
+        Drive.
+      </p>
+
+      <h2>3. Google Drive integration</h2>
+      <p>
+        If you connect Google Drive, you authorize the app to open and save files that you select or
+        create with it, using Google's <code>drive.file</code> permission. Your use of Google Drive is
+        also governed by
+        <a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer"
+          >Google's Terms of Service</a
+        >. You are responsible for your Google account and the content you store there. See our
+        <a href="/privacy.html">Privacy Policy</a> for how Drive data is handled.
+      </p>
+
+      <h2>4. Acceptable use</h2>
+      <p>You agree not to use the app to:</p>
+      <ul>
+        <li>violate any applicable law or the rights of others;</li>
+        <li>create, store, or distribute unlawful, infringing, or harmful content;</li>
+        <li>attempt to disrupt, attack, or reverse-engineer the service in a harmful way.</li>
+      </ul>
+      <p>
+        You retain all rights to the documents you create. You are solely responsible for your
+        content and for keeping your own backups.
+      </p>
+
+      <h2>5. Disclaimer of warranties</h2>
+      <p>
+        The app is provided "as is" and "as available", without warranties of any kind, whether
+        express or implied, including fitness for a particular purpose and non-infringement. We do not
+        warrant that the app will be uninterrupted, error-free, or that any data will be preserved.
+        Always keep your own backups of important documents.
+      </p>
+
+      <h2>6. Limitation of liability</h2>
+      <p>
+        To the maximum extent permitted by law, Z-Editor and its contributors shall not be liable for
+        any indirect, incidental, special, consequential, or punitive damages, or any loss of data,
+        arising out of or related to your use of the app.
+      </p>
+
+      <h2>7. Changes</h2>
+      <p>
+        We may modify or discontinue the app, or update these terms, at any time. Changes are posted
+        on this page with a new "Last updated" date. Continued use after changes constitutes
+        acceptance.
+      </p>
+
+      <h2>8. Contact</h2>
+      <p>
+        Questions about these terms? Email
+        <a href="mailto:opensldev@gmail.com">opensldev@gmail.com</a> or open an issue on
+        <a
+          href="https://github.com/Z-Editor/Z-Editor/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          >GitHub</a
+        >.
+      </p>
+
+      <footer>
+        <a href="/">&larr; Back to Z-Editor</a> · <a href="/privacy.html">Privacy Policy</a>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -15,3 +15,19 @@
 .statusbar-item {
   white-space: nowrap;
 }
+
+.statusbar-links {
+  margin-left: auto;
+  display: flex;
+  gap: 16px;
+}
+
+.statusbar-links a {
+  color: #5f6368;
+  text-decoration: none;
+}
+
+.statusbar-links a:hover {
+  color: #1a73e8;
+  text-decoration: underline;
+}

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -23,6 +23,14 @@ const StatusBar: ComponentType<StatusBarProps> = ({ editorState }) => {
         {words} {words === 1 ? 'word' : 'words'}
       </span>
       <span className="statusbar-item">{text.length} characters</span>
+      <span className="statusbar-links">
+        <a href="/privacy.html" target="_blank" rel="noopener noreferrer">
+          Privacy
+        </a>
+        <a href="/terms.html" target="_blank" rel="noopener noreferrer">
+          Terms
+        </a>
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Adds a **Privacy Policy** and **Terms of Service**, required for Google OAuth production verification of the `drive.file` scope.

Both are shipped as **static HTML in `public/`**, so Vite copies them to the site root and they deploy to:
- `https://z-editor.github.io/privacy.html`
- `https://z-editor.github.io/terms.html`

They load on a direct GET — no router, no SPA 404 fallback, no dependency — exactly what Google's verification crawler needs.

## Details

- **Privacy Policy** includes the required **Google API Services User Data Policy / Limited Use** disclosure, and documents how GA4 analytics and Google Drive (`drive.file`) data are handled (client-side only, no server storage). Contact: opensldev@gmail.com + GitHub Issues.
- **Terms of Service**: as-is service, Drive usage, acceptable use, disclaimer, limitation of liability.
- **In-app links**: Privacy and Terms added to the status bar (open in a new tab).

## Testing

- `yarn build` copies both files to `dist/`; verified in-browser rendering.
- Existing tests pass.

## Follow-ups (manual, for OAuth verification)

- Set App homepage and these two URLs in the OAuth consent screen.
- Verify `z-editor.github.io` as an authorized domain in Google Search Console (HTML-file method via `public/`).

> These documents are a good-faith template, not legal advice — please review before relying on them.
